### PR TITLE
Fix typos

### DIFF
--- a/docs/API/Buttons.md
+++ b/docs/API/Buttons.md
@@ -1,15 +1,15 @@
 # Button Input
 
-There are 6 total individual buttons available to use as input for Thumby. 4 directional buttions for up, down, left, and right, and there are two action buttons. Multiple buttons can be combined to add more button actions to gameplay.
+There are 6 total individual buttons available to use as input for Thumby. 4 directional buttons for up, down, left, and right, and there are two action buttons. Multiple buttons can be combined to add more button actions to gameplay.
 
 ### Objects
 
 * `thumby.buttonA` | for accessing A button (right red button)
 * `thumby.buttonB` | for accessing B button (left red button)
-* `thumby.buttonU` | for accessing up direction on DPAD
-* `thumby.buttonD` | for accessing down direction on DPAD
-* `thumby.buttonL` | for accessing left direction on DPAD
-* `thumby.buttonR` | for accessing right direction on DPAD
+* `thumby.buttonU` | for accessing Up direction on d-pad
+* `thumby.buttonD` | for accessing Down direction on d-pad
+* `thumby.buttonL` | for accessing Left direction on d-pad
+* `thumby.buttonR` | for accessing Right direction on d-pad
 
 ### Methods
 * `thumby.buttonX.pressed()` 
@@ -23,9 +23,9 @@ There are 6 total individual buttons available to use as input for Thumby. 4 dir
 * `inputJustPressed()`
     * Returns true if any buttons were just pressed on the thumby.
 * `dpadPressed()`
-    * Returns true if any dpad buttons are currently pressed on the thumby.
+    * Returns true if any d-pad buttons are currently pressed on the thumby.
 * `dpadJustPressed()`
-    * Returns true if any dpad buttons were just pressed on the thumby.
+    * Returns true if any d-pad buttons were just pressed on the thumby.
 * `actionPressed()`
     * Returns true if either action button is pressed on the thumby.
 * `actionJustPressed()`

--- a/docs/API/Buttons.md
+++ b/docs/API/Buttons.md
@@ -61,7 +61,7 @@ dpadSpr = thumby.Sprite(21, 21, dpadMap, 10, 10)
 while(True):
     thumby.display.fill(0) # Fill canvas to black
     
-    # draw the dpad sprite first so the text is placed over it
+    # draw the d-pad sprite first so the text is placed over it
     thumby.display.drawSprite(dpadSpr) 
     
     # Up, down, left, right, and action a, and b button movement logic

--- a/docs/API/Graphics.md
+++ b/docs/API/Graphics.md
@@ -21,7 +21,7 @@ Use these screen dimension constants in place of the actual pixel dimensions of 
 
 `thumby.display.update()` | updates screen at frames-per-second (FPS) specified by 
 
-`thumby.display.setFPS(...)`. This function will block updates to maintain the set FPS setting. Default framerate 0 (non-limited). Returns `None`
+`thumby.display.setFPS(...)`. This function will block updates to maintain the set FPS setting. Default frame rate 0 (non-limited). Returns `None`
 
 --- 
 

--- a/docs/API/Hardware.md
+++ b/docs/API/Hardware.md
@@ -2,7 +2,7 @@
 
 A great way to close your game when the player has finished playing is to offer a menu along the lines of "Play Again: B, Quit: A" To communicate to the player which button should be pressed to quit the game and return to the main menu, or to give them a chance to replay the game without restarting from the main menu. 
 
-Since Thumby games are written in MicroPython, the main game files have a .py extension and function like any normal script written in refular Python. A acript is a sequence of instructions that is carried out and then ends, so it's possible that your game script is already ending and returning to the main menu by itself when the player is done playing your game. You can write and test your game in this way, or you can add the `.reset()` command to take out the possibility of any logic errors. 
+Since Thumby games are written in MicroPython, the main game files have a .py extension and function like any normal script written in regular Python. A script is a sequence of instructions that is carried out and then ends, so it's possible that your game script is already ending and returning to the main menu by itself when the player is done playing your game. You can write and test your game in this way, or you can add the `.reset()` command to take out the possibility of any logic errors. 
 
 This short example shows how it might be used to tell the player how to exit the game: 
 

--- a/docs/API/Sprites.md
+++ b/docs/API/Sprites.md
@@ -34,7 +34,7 @@
 
 ---
 
-`Sprite.setFrame(frame)` | sets the current `frame` index of the sprite animation. Needs to be used manually to progress animation, framerate handled by `thumby.display.update()`. Returns none, all parameters required.
+`Sprite.setFrame(frame)` | sets the current `frame` index of the sprite animation. Needs to be used manually to progress animation, frame rate handled by `thumby.display.update()`. Returns none, all parameters required.
 
 * `frame`
     * type: int

--- a/docs/API/Text-and-Font.md
+++ b/docs/API/Text-and-Font.md
@@ -28,7 +28,7 @@ Text is important for communication, scores, and displaying the title of a game.
 ## Setting Font
 
 
-You can use any font you would like with the Thumby. The default font on the Thumby is 5x7, but there is also an 8x8 font included with the Thumby software under the lib/ folder. 
+You can use any font you would like with the Thumby. The default font on the Thumby is 5×7, but there is also an 8×8 font included with the Thumby software under the lib/ folder. 
 
 `thumby.display.setFont(fontFilePath, width, height, space)` | sets the `fontFilePath` pointing to binary font file with character `width`, `height`, and `space` between characters for use by `thumby.display.drawText(...)`. Returns None, all parameters required.
 

--- a/docs/CCPP/Uploading-Sketches.md
+++ b/docs/CCPP/Uploading-Sketches.md
@@ -18,8 +18,8 @@ Leave the port blank for the first upload - it will be set later
 2. Open an example using `File -> Examples -> Thumby -> ThumbySimpleExample`
 3. Put Thumby into BOOTSEL mode:
     1. Turn Thumby off
-    2. Press and hold the down DPAD direction
-    3. Turn Thumby on while continuing to hold the down DPAD direction
+    2. Press and hold the down d-pad direction
+    3. Turn Thumby on while continuing to hold the down d-pad direction
     4. Wait for a file explorer to pop up on the computer or for the "RPI-RP2" volume to automatically mount
     5. Click "Upload" in the top left of the IDE and wait for the "Done uploading" message above the console
     6. Select `Tools -> Port: -> XXX(Raspberry Pi Pico)` (select the port marked as a pico)

--- a/docs/Code-Editor/Arcade-games.md
+++ b/docs/Code-Editor/Arcade-games.md
@@ -22,7 +22,7 @@ A few mentions of awesome game developers:
 <center><iframe width="560" height="315" src="https://www.youtube.com/embed/dEVXW3sdPtM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>
 <center>*Caution: This one has some mature language that may not be suited for all ages*</center>
 
-Play all the games you want - be sure to check back occasionally to see new games that get added to the Arcade! [_**Learn how to submit your own**_](https://tinycircuits.com/blogs/learn/thumby-tutorial-submitting-a-game "How to submit thumby games using github tutorial").
+Play all the games you want - be sure to check back occasionally to see new games that get added to the Arcade! [_**Learn how to submit your own**_](https://tinycircuits.com/blogs/learn/thumby-tutorial-submitting-a-game "How to submit thumby games using GitHub tutorial").
 
 ---
 

--- a/docs/Code-Editor/Get-Started.md
+++ b/docs/Code-Editor/Get-Started.md
@@ -176,7 +176,7 @@ For your project to show up on the Thumby game select screen, there needs to be 
 ![Thumby Code Editor screenshot of file system and emulation](/images/Editor-upload.jpg)
 <center>*Setup before clicking 'Upload'*</center>
 
-Now click the 'Upload' button on the bottom of the Filesystem panel, disconnect Thumby, power cycle it (turn off and on), use down on the Thumby dpad to find your project, click the left button to select and execute your main project file.
+Now click the 'Upload' button on the bottom of the Filesystem panel, disconnect Thumby, power cycle it (turn off and on), use down on the Thumby d-pad to find your project, click the left button to select and execute your main project file.
 
 If the above code was used, the below animation will play after selecting 'HelloWorld' in the Thumby select screen:
 

--- a/docs/Code-Editor/Making-a-game.md
+++ b/docs/Code-Editor/Making-a-game.md
@@ -39,18 +39,18 @@ Connect your Thumby using the "CONNECT THUMBY" button at the top of the Code Edi
 ## Game Design Basics
 
 
-The Thumby screen is a monochrome OLED with 72x40 drawable pixels. With this in mind, complex game graphics like those seen in modern games are not very possible with the limitations of the screen. Creating smaller game sprites and limiting text are some of the strategies that make simple games on Thumby work best. The Thumby API font implements a 5x7 character size, which leads to around 12 displayable characters per row, and 5 per column. So a story game with a lot of text may not be right type of game for the Thumby's screen size. 
+The Thumby screen is a monochrome OLED with 72×40 drawable pixels. With this in mind, complex game graphics like those seen in modern games are not very possible with the limitations of the screen. Creating smaller game sprites and limiting text are some of the strategies that make simple games on Thumby work best. The Thumby API font implements a 5×7 character size, which leads to around 12 displayable characters per row, and 5 per column. So a story game with a lot of text may not be right type of game for the Thumby's screen size. 
 
 ### Conceptualizing and Visualizing Your Game
 
 Steps:
 
 1.  Create sample art of what gameplay might look like (if possible) - this will help you get started with creating game elements in the right size that you will need later on - keep in mind that the actual thumby screen is only 0.42" 
-2.  Visualize a 72x40 grid for your game when you start creating sample sprites or art - you can use the bitmap builder available from the Thumby Code Editor to start drafting up some static images of gameplay. 
+2.  Visualize a 72×40 grid for your game when you start creating sample sprites or art - you can use the bitmap builder available from the Thumby Code Editor to start drafting up some static images of gameplay. 
 
 
-<center>![Thumby Code Editor bitmap builder of 72x40](https://cdn.shopify.com/s/files/1/1125/2198/files/image_1_af351171-657d-43c0-a525-28c3f2766846.png?v=1640597713)</center>
-<center>_Thumby Code Editor bitmap builder of 72x40_</center>
+<center>![Thumby Code Editor bitmap builder of 72×40](https://cdn.shopify.com/s/files/1/1125/2198/files/image_1_af351171-657d-43c0-a525-28c3f2766846.png?v=1640597713)</center>
+<center>_Thumby Code Editor bitmap builder of 72×40_</center>
 
 You can make the bitmap builder full screen, zoom in, and draw up some bitmap ideas to help visualize the size and possibilities. Keep in mind that you will eventually want each bitmap, or game element by itself, rather than as a part of a full screen bitmap to keep your game efficient.
 
@@ -243,7 +243,7 @@ while(1):
 
 At this point, you have a moving Game Paddle that can bounce the Ball, the Ball can bounce against all the bounds of the game screen except the bottom of the screen which triggers the "Game Over" screen.
 
-The code is getting pretty long, so let's just add the remaining components separately! You can comfortably fit around 3 rows of 10 bricks on the screen with the brick size 6x3. So we need to display all the bricks and make them able to store the data of being collided or not per each of the 30 bricks. I chose to implement this with a **Brick class** that holds a collision variable, and a function that will delete, or move the **Brick** off the screen when collision is detected.
+The code is getting pretty long, so let's just add the remaining components separately! You can comfortably fit around 3 rows of 10 bricks on the screen with the brick size 6×3. So we need to display all the bricks and make them able to store the data of being collided or not per each of the 30 bricks. I chose to implement this with a **Brick class** that holds a collision variable, and a function that will delete, or move the **Brick** off the screen when collision is detected.
 
 With **Bricks** added to the game, we can keep score of how many are broken to Win the game! We can also add some more functionality to the Game Over menu to restart the game, or take the user back to the main Thumby menu using _thumby.reset()_. These components:
 

--- a/docs/Code-Editor/Spritesheet.md
+++ b/docs/Code-Editor/Spritesheet.md
@@ -34,7 +34,7 @@ To frame the frames you'd like to import, you'll need to edit the number of fram
 
 Then, change the Frame width and height (px) values to match the frames. You can divide the total width of pixels, in this case 250, by 'X frame count' 5 to get the correct 'Frame width (px)', and do the same for the height - 90 / 2 = 45 for the 'Frame height (px)'. If your frames are offset or aren't fitting using this method - use the arrows for the 'X and Y grid offset' or the 'X and Y grid gap' values to get the frame values that work for you.
 
-Note: Spritesheets, and therefore sprites that are too big (larger than 72x40) will not fully display on the Thumby screen. Depending on the number and size of frames, you may get a memory error. Resize your image to smaller pixel values to solve this issue.
+Note: Spritesheets, and therefore sprites that are too big (larger than 72×40) will not fully display on the Thumby screen. Depending on the number and size of frames, you may get a memory error. Resize your image to smaller pixel values to solve this issue.
 
 <center>
 ![Import Sprite image 4](/images/import-sprite-frame-overlay.jpg)

--- a/docs/Code-Editor/Spritesheet.md
+++ b/docs/Code-Editor/Spritesheet.md
@@ -1,6 +1,6 @@
 # Import Spritesheet
 
-Animations are important for gameplay and aesthethic appearance. One of the best ways to animate a Sprite or graphic is to use a spritesheet with all the different frames of animation in one place.
+Animations are important for gameplay and aesthetic appearance. One of the best ways to animate a Sprite or graphic is to use a spritesheet with all the different frames of animation in one place.
 
 ---
 
@@ -32,7 +32,7 @@ To frame the frames you'd like to import, you'll need to edit the number of fram
 *Sprite altered x and y count*
 </center>
 
-Then, change the Frame width and height(px) values to match the frames. You can divide the total width of pixels, in this case 250, by 'X frame count' 5 to get the correct 'Frame width (px)', and do the same for the height - 90 / 2 = 45 for the 'Frame height (px)'. If your frames are offset or aren't fitting using this method - use the arrows for the 'X and Y grid offset' or the 'X and Y grid gap' values to get the frame values that work for you.
+Then, change the Frame width and height (px) values to match the frames. You can divide the total width of pixels, in this case 250, by 'X frame count' 5 to get the correct 'Frame width (px)', and do the same for the height - 90 / 2 = 45 for the 'Frame height (px)'. If your frames are offset or aren't fitting using this method - use the arrows for the 'X and Y grid offset' or the 'X and Y grid gap' values to get the frame values that work for you.
 
 Note: Spritesheets, and therefore sprites that are too big (larger than 72x40) will not fully display on the Thumby screen. Depending on the number and size of frames, you may get a memory error. Resize your image to smaller pixel values to solve this issue.
 

--- a/docs/Code-Editor/Submit-Game.md
+++ b/docs/Code-Editor/Submit-Game.md
@@ -35,7 +35,7 @@ Once your game is in a state where you are ready to share it with everyone and p
 
 * *GameName/GameName.py* - The main file of your game that references any other files, like a .bin or .raw image you use in the game - include all files needed for your main game file to work!
 * *GameName/arcade_description.txt* - Include the title of your game, a short description, your name, and the version of your game. Add any instructions important to play your game. This text is displayed when hovering over your game in the Thumby Arcade.
-* *GameName/arcade_title_video.webm* - A .webm video of gameplay. Use the video camera 🎥 button in the Emulator panel of the Thumby Code Editor Website to record a .webm of gameplay. Zoom in to at least 8x to provide a good quality video. The zoom factor displays in the bottom left of the Emulator.
+* *GameName/arcade_title_video.webm* - A .webm video of gameplay. Use the video camera 🎥 button in the Emulator panel of the Thumby Code Editor Website to record a .webm of gameplay. Zoom in to at least 8× to provide a good quality video. The zoom factor displays in the bottom left of the Emulator.
 
 ---
 

--- a/docs/Code-Editor/Widget-panels.md
+++ b/docs/Code-Editor/Widget-panels.md
@@ -43,7 +43,7 @@ Where Thumby game files are stored.
 
 For every game folder, there should be a main python script to run that is the same name of the folder. 
 
-To add your game to Thumby, place the game file in */Games/MyNewGame/MyNewGame.py* to add it to the playable Thumby 'GAMES' list. Make sure your python file has the exact same name as the game. Ie. if the game is called *TinyBlocks*, the source file is named *TinyBlocks.py*. The title is case sensitive, so *tinyblocks.py* would not work.
+To add your game to Thumby, place the game file in */Games/MyNewGame/MyNewGame.py* to add it to the playable Thumby 'GAMES' list. Make sure your python file has the exact same name as the game: i.e. if the game is called *TinyBlocks*, the source file is named *TinyBlocks.py*. The title is case sensitive, so *tinyblocks.py* would not work.
 
 > For more information, check out this page: [**Submitting a Game to the Thumby Arcade**](/Code-Editor/Submit-Game.md)
 
@@ -52,11 +52,11 @@ To add your game to Thumby, place the game file in */Games/MyNewGame/MyNewGame.p
 
 A simple drawing interface to create and edit code bitmaps. Left click to draw black pixels. Right click to draw white pixels.
 
-* SIZE: Change the SIZE (width and height) of the bitmap. Bitmaps and sprites can be as large as the user wants. However, the bitmap builder can only handle images up to 144px x 80px. The larger the bitmap, the slower it will be rendered to the Thumby display.
+* SIZE: Change the SIZE (width and height) of the bitmap. Bitmaps and sprites can be as large as the user wants. However, the bitmap builder can only handle images up to 144 × 80 px. The larger the bitmap, the slower it will be rendered to the Thumby display.
 * +/-: Zoom in/out of the Bitmap Builder using the +/- buttons.
 * EXPORT: Put your mouse cursor at the location in your Code Editor you want to export your drawing data to, then click the EXPORT button. A comment with size dimensions and a bitmap will be printed in the Code Editor.
 * IMPORT: Highlight a bitmap and the exported dimensions comment in your code and click IMPORT to view the drawing in the Bitmap Builder.
-* IMAGE: Import your own IMAGE to be converted into a bitmap. Most image formats will work, but the maximum image size is 2x Thumby display dimensions,  144px x 80px. An error will appear if the image exceeds maximum size. 
+* IMAGE: Import your own IMAGE to be converted into a bitmap. Most image formats will work, but the maximum image size is 2× Thumby display dimensions,  144 × 80 px. An error will appear if the image exceeds maximum size. 
 * INVERT: Inverts black and white pixels to white and black pixels, respectively. 
 * CLEAR: Clears the bitmap editor to white pixels.
 
@@ -76,7 +76,7 @@ Where code is written and displayed. By default, the editor will have a Thumby s
 
 * VIEW: Change display of Editor. Adjust and reset font size. Toggle live autocomplete.
 * FAST EXECUTE: When pressed, will execute a single file at the root level of a connected Thumby device. 
-* EMULATION: Click both the white and red checkbox to test the file in the Emulator. The white box uploads the file (script) to the emulator’s filesystem. The red box designates a script as the main script to run. Because of how Thumby works, only 1 file (main script, red checkbox) can be executed at a time. However, users may want to include other files that are not the main script during emulation (ie. binary sprite files or other modules). Check the white box for those supplementary files. 
+* EMULATION: Click both the white and red checkbox to test the file in the Emulator. The white box uploads the file (script) to the emulator’s filesystem. The red box designates a script as the main script to run. Because of how Thumby works, only 1 file (main script, red checkbox) can be executed at a time. However, users may want to include other files that are not the main script during emulation (e.g. binary sprite files or other modules). Check the white box for those supplementary files. 
 
 ---
 ## Shell
@@ -90,7 +90,7 @@ This panel with a virtual Thumby emulates what your code will look like on the h
 
 The emulator will not display the main game menu seen on the Thumby hardware, it will only emulate files in the Code Editor that are selected for emulation.
 
-To upload a file to the emulator, check the white and red checkboxes in the Code Editor panel with the file you want to emulate. The white box uploads the file (script) to the emulator’s filesystem. The red box designates a script as the main script to run. Because of how Thumby works, only 1 file (main script, red checkbox) can be executed at a time on the device. However, users may want to include other files that are not the main script during emulation (ie. binary sprite files or other modules). Check the white box for those supplementary files.
+To upload a file to the emulator, check the white and red checkboxes in the Code Editor panel with the file you want to emulate. The white box uploads the file (script) to the emulator’s filesystem. The red box designates a script as the main script to run. Because of how Thumby works, only 1 file (main script, red checkbox) can be executed at a time on the device. However, users may want to include other files that are not the main script during emulation (e.g. binary sprite files or other modules). Check the white box for those supplementary files.
 
 * STOP: Stop emulation.
 * START: Start emulation of the checked files in the Code Editor. 

--- a/docs/Education/Change-Thumby-Start-Logo.md
+++ b/docs/Education/Change-Thumby-Start-Logo.md
@@ -4,7 +4,7 @@ To change the start up logos, you will need an image to replace the TinyCircuits
 
 - **TClogo.bin**
 
-      - The TinyCircuits logo flashes momentarily on the screen when turning the Thumby on. There is nothing else on the screen at this point, so you can use the full screen dimensions for a replacement: 72x40 pixels
+      - The TinyCircuits logo flashes momentarily on the screen when turning the Thumby on. There is nothing else on the screen at this point, so you can use the full screen dimensions for a replacement: 72×40 pixels
 
 - **thumbyLogo.bin**
 
@@ -62,7 +62,7 @@ Save your image file to the lib/ directory and whatever you name it in this step
 
 ## Replace Thumby Logo
 
-Since the image we made earlier is 72x40 pixels, it will work best as the start up logo, or the _TClogo.bin_. Rename the _TCLogo.bin_ to something like _orig-TCLogo.bin_ to signify that it is the original logo. Rename the .bin image file you saved in the previous step to _TClogo.bin_:
+Since the image we made earlier is 72×40 pixels, it will work best as the start up logo, or the _TClogo.bin_. Rename the _TCLogo.bin_ to something like _orig-TCLogo.bin_ to signify that it is the original logo. Rename the .bin image file you saved in the previous step to _TClogo.bin_:
 
 <center>
 ![Rename sprite sheet](/images/logo-sprite-sheet-rename.jpg)

--- a/docs/Education/Move-Sprite.md
+++ b/docs/Education/Move-Sprite.md
@@ -8,7 +8,7 @@ thumby.display.fill(0) # Fill canvas with black pixels to 'clear' the screen
 thumby.display.update()
 ```
 
-This next example will show a spaceship sprite that moves around the screen depending on which buttons on the D-pad are pressed, up, down, left, and right. A combination of 2 buttons being pressed will move the sprite between the two directions - so your sprite can move 8 directions using just 4 buttons!
+This next example will show a spaceship sprite that moves around the screen depending on which buttons on the d-pad are pressed, up, down, left, and right. A combination of 2 buttons being pressed will move the sprite between the two directions - so your sprite can move 8 directions using just 4 buttons!
 
 Note that the spaceship will move off the screen with this code snippet since there is no bounding logic. Check out the [bounded ball page](Bounded-ball.md) for more information on keeping a sprite within view. 
 
@@ -16,7 +16,7 @@ Note that the spaceship will move off the screen with this code snippet since th
 ![Bouncing ball](/images/move-ship-sprite.gif)
 </center>
 <center>
-*Spaceship moving around using D-pad buttons*
+*Spaceship moving around using d-pad buttons*
 </center>
 
 ```py

--- a/docs/Education/Play-Video.md
+++ b/docs/Education/Play-Video.md
@@ -75,7 +75,7 @@ From there, you can move the black track to a separate _Output_ and extend it to
 ![Shotcut add black color](/images/Shotcut-black-track-background.JPG)
 </center>
 
-The last filter to add would be _Crop: Source_ to remove the YouTube watermark and resize the video to better fit the Thumby screen dimensions of 72x40 pixels:
+The last filter to add would be _Crop: Source_ to remove the YouTube watermark and resize the video to better fit the Thumby screen dimensions of 72×40 pixels:
 
 <center>
 ![Shotcut crop source filter applied](/images/Shotcut-crop-filter.jpg)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -20,7 +20,7 @@ If one of the below options doesn't answer your question(s), you can post on the
 
     1.  Plug Thumby into a computer
     2.	Turn Thumby off
-    3.	Turn Thumby on while holding the down D-Pad button (*Note: Earlier revisions of Thumby may require pressing one of the red action buttons instead of the down D-Pad button*)
+    3.	Turn Thumby on while holding the down d-pad button (*Note: Earlier revisions of Thumby may require pressing one of the red action buttons instead of the down d-pad button*)
     4.	Wait for a file explorer to pop up or for the 'RPI-RP2' device to mount 
     5.	<a href="https://github.com/TinyCircuits/TinyCircuits-Thumby-Code-Editor/raw/master/ThumbyFirmware.uf2" alt="tinycircuits thumby code editor repository">**Download the ThumbyFirmware.uf2 file**</a>
     6.	Drag and drop the **ThumbyFirmware.uf2** file to the 'RPI-RP2' device (WARNING: this will delete all Thumby files)
@@ -38,7 +38,7 @@ To test games or changes you upload to the Thumby, you will need to disconnect t
 
 **Can I change the audio and brightness?**
 
-Yes! Turn on the Thumby, scroll down once to the 'GAMES' menu and right once to view the 'SETTINGS'. Here you can press the DPAD down button to the setting you want to alter and press either red action button to change the setting mode:
+Yes! Turn on the Thumby, scroll down once to the 'GAMES' menu and right once to view the 'SETTINGS'. Here you can press the d-pad down button to the setting you want to alter and press either red action button to change the setting mode:
 
 * Audio: On/Off
 * Brightness: Mid/Hi/Low     *-- Note: we couldn't fit the whole word Brightness on the screen, so it reads as just Brite*
@@ -51,7 +51,7 @@ The changes automatically save after being changed.
 
 **Where is the credits menu and whose names are on it?**
 
-To view the credits menu on the Thumby, turn Thumby on, scroll down once to the 'GAMES' menu and press the DPAD button right twice to scroll past the 'SETTINGS' menu to see the credits roll 4 names at a time.
+To view the credits menu on the Thumby, turn Thumby on, scroll down once to the 'GAMES' menu and press the d-pad button right twice to scroll past the 'SETTINGS' menu to see the credits roll 4 names at a time.
 
 Kickstarter backers that selected a Special Edition Thumby were able to submit one 16 character name (or something) on the credits list per Special Edition Thumby purchased. To view the full credits list, you can connect Thumby to the <a href="https://code.thumby.us/" target="_blank" alt="TinyCircuits Thumby Web Browser Code Editor page">**Thumby Code Editor**</a> and view the credits.txt file from the 'filesystem' directory.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,10 +113,10 @@ Check out our [**documentation for the Arduino C/C++ library**](/CCPP/API-Refere
   <li><b>Processor</b>: Raspberry Pi Pico RP2040 Processor</li>
   <li><b>Memory</b> 2MB total storage</li>
   <li><b>Connectivity</b> micro USB for programming & multiplayer using <b>Thumby Link cable</b></li>
-  <li><b>Outputs</b> 72x40 Monochrome OLED Display, Piezo Speaker</li>
+  <li><b>Outputs</b> 72×40 px Monochrome OLED Display, Piezo Speaker</li>
   <li><b>Inputs</b> 6 tactile buttons (4-way d-pad, 2 action buttons)</li>
   <li><b>Power</b> Power switch, 40mAh Rechargeable LiPo Battery, ~2 hours of gameplay</li>
-  <li><b>Dimensions</b> 1.2" X 0.7" X 0.3" (29.5mm x 18mm x 8.5mm) - Sturdy polycarbonate plastic case with a built-in rechargeable battery and buzzer</li>
+  <li><b>Dimensions</b> 1.2 × 0.7 × 0.3" (29.5 × 18 × 8.5mm) - Sturdy polycarbonate plastic case with a built-in rechargeable battery and buzzer</li>
   <li><b>Programming</b> MicroPython using the Thumby Code Editor or Arduino Code Editor - create your own games! </li>
   <li>Multiplayer support via <b>Thumby Link cable</b></li>
 </ul>

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,7 +114,7 @@ Check out our [**documentation for the Arduino C/C++ library**](/CCPP/API-Refere
   <li><b>Memory</b> 2MB total storage</li>
   <li><b>Connectivity</b> micro USB for programming & multiplayer using <b>Thumby Link cable</b></li>
   <li><b>Outputs</b> 72x40 Monochrome OLED Display, Piezo Speaker</li>
-  <li><b>Inputs</b> 6 tactile buttons (4-way D-pad, 2 action buttons)</li>
+  <li><b>Inputs</b> 6 tactile buttons (4-way d-pad, 2 action buttons)</li>
   <li><b>Power</b> Power switch, 40mAh Rechargeable LiPo Battery, ~2 hours of gameplay</li>
   <li><b>Dimensions</b> 1.2" X 0.7" X 0.3" (29.5mm x 18mm x 8.5mm) - Sturdy polycarbonate plastic case with a built-in rechargeable battery and buzzer</li>
   <li><b>Programming</b> MicroPython using the Thumby Code Editor or Arduino Code Editor - create your own games! </li>
@@ -177,7 +177,7 @@ Check out our [**documentation for the Arduino C/C++ library**](/CCPP/API-Refere
 
 <p></p>
 <div id="rcorners1">
-  <p id="no-padding"><em>"How small is this... roughly the size of the D-pad!"</em> </p>
+  <p id="no-padding"><em>"How small is this... roughly the size of the d-pad!"</em> </p>
   <p align="right" id="no-padding"><a href="https://nintendowire.com/news/2021/09/22/thumby-the-worlds-smallest-gaming-handheld-headed-to-kickstarter-on-september-28th/" target="_blank" alt="TinyCircuits Thumby Article Blog"><b>-Nintendo Wire</b></a></p>
 </div>
 


### PR DESCRIPTION
- Correct small typos (thanks @Reznullius).
- Make use of ‘d-pad’ consistent.